### PR TITLE
    feat: add script to create a token, loop through it and aggregate token JSON files to make only one file

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ If you want to go fast to the soroban CLI experiment, just run:
 
 To test the Pair contract, inside the `soroban-preview-9` container run:
 ```bash
-bash intialize_pair.sh standalone
+bash initialize_pair.sh standalone
 ```
 
 To test the Pair contract, inside the `soroban-preview-9` container run:
 ```bash
-bash intialize_factory.sh standalone
+bash initialize_factory.sh standalone
 ```

--- a/scripts/create_token.sh
+++ b/scripts/create_token.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# This script takes two arguments:
+# $1: The network to deploy the token to
+# $2: The address of the token admin account
+# Then it deploys the token contract to the network and initializes it
+# Then it saves the token contract address and token id to a file on .soroban/temp_token.json
+
+NETWORK="$1"
+TOKEN_ADMIN_ADDRESS="$2"
+
+mkdir -p /workspace/.soroban
+
+TOKEN_WASM="/workspace/token/soroban_token_contract.wasm"
+
+echo Deploying TOKEN_A
+echo $NETWORK
+echo $TOKEN_WASM
+
+TOKEN_A_ID="$(
+  soroban contract deploy --network $NETWORK --source token-admin \
+    --wasm $TOKEN_WASM
+  )"
+echo TOKEN_A_ID: $TOKEN_A_ID
+
+echo Initializing TOKEN_A
+echo "Executing: 
+  fn initialize(  e: Env,
+                  admin: Address,
+                  decimal: u32,
+                  name: Bytes,
+                  symbol: Bytes) {
+  "
+
+soroban contract invoke \
+  --network $NETWORK --source token-admin \
+  --wasm $TOKEN_WASM \
+  --id $TOKEN_A_ID \
+  -- \
+  initialize \
+  --admin "$TOKEN_ADMIN_ADDRESS" \
+  --decimal 7 \
+  --name 'AA' \
+  --symbol 'AA'
+
+# Save the token contract address and token id to a file on .soroban/temp_token.json
+echo "{\"token_id\": \"$TOKEN_A_ID\", \"token_address\": \"$TOKEN_ADMIN_ADDRESS\"}" > /workspace/.soroban/temp_token.json

--- a/scripts/setup_and_create_tokens.sh
+++ b/scripts/setup_and_create_tokens.sh
@@ -1,0 +1,74 @@
+# Run script from project root
+
+set -e
+
+NETWORK="$1"
+N_TOKENS="$2"
+# Verifies that N_TOKENS should be an integer
+
+
+# If soroban-cli is called inside the soroban-preview docker containter,
+# it can call the stellar standalone container just using its name "stellar"
+SOROBAN_RPC_HOST="http://stellar:8000"
+
+SOROBAN_RPC_URL="$SOROBAN_RPC_HOST/soroban/rpc"
+
+case "$1" in
+standalone)
+  echo "Using standalone network"
+  SOROBAN_NETWORK_PASSPHRASE="Standalone Network ; February 2017"
+  FRIENDBOT_URL="$SOROBAN_RPC_HOST/friendbot"
+  ;;
+futurenet)
+  echo "Using Futurenet network"
+  SOROBAN_NETWORK_PASSPHRASE="Test SDF Future Network ; October 2022"
+  FRIENDBOT_URL="https://friendbot-futurenet.stellar.org/"
+  ;;
+*)
+  echo "Usage: $0 standalone|futurenet"
+  exit 1
+  ;;
+esac
+
+# Always set a net configuration 
+echo Add the $NETWORK network to cli client
+soroban config network add "$NETWORK" \
+  --rpc-url "$SOROBAN_RPC_URL" \
+  --network-passphrase "$SOROBAN_NETWORK_PASSPHRASE"
+
+if !(soroban config identity ls | grep token-admin 2>&1 >/dev/null); then
+  echo Create the token-admin identity
+  soroban config identity generate token-admin
+fi
+TOKEN_ADMIN_SECRET="$(soroban config identity show token-admin)"
+TOKEN_ADMIN_ADDRESS="$(soroban config identity address token-admin)"
+
+echo "We are using the following TOKEN_ADMIN_ADDRESS: $TOKEN_ADMIN_ADDRESS"
+
+
+
+# # Run the script create_token.sh to create the token
+# bash /workspace/scripts/create_token.sh $NETWORK $TOKEN_ADMIN_ADDRESS
+# # Get the token contract address and token id from the file on .soroban/temp_token.json
+
+
+# Initialize an empty JSON array in all_tokens.json
+touch /workspace/.soroban/all_tokens.json
+echo "[]" > /workspace/.soroban/all_tokens.json
+
+# Loop from 1 to N_TOKENS
+for i in $(seq 1 $N_TOKENS); do
+    # Run the script that generates temp_token.json (replace ./your_script.sh with the actual script)
+    bash /workspace/scripts/create_token.sh $NETWORK $TOKEN_ADMIN_ADDRESS
+
+    # Read the contents of temp_token.json
+    temp_token=$(cat /workspace/.soroban/temp_token.json)
+
+    # Add the contents of temp_token.json to the all_tokens.json array
+    temp=$(mktemp)
+    jq --argjson new_token "$temp_token" '. += [$new_token]' /workspace/.soroban/all_tokens.json > "$temp" && mv "$temp" /workspace/.soroban/all_tokens.json
+done
+
+# Display the final JSON file
+cat /workspace/.soroban/all_tokens.json
+


### PR DESCRIPTION
  - Implemented scripts/create_token.sh: which creates a token given a network and an admin-token
    - Implemented a bash script that loops through a given N_tokens number and creates token, saving info into a single JSON array.
    - Utilized `jq` to efficiently handle and merge JSON content.
    - Added error handling to ensure the script exits gracefully if needed files are not found.

