### PR TITLE
fix(pair): string concat will never have more than 35 chars. Fix#168

### DIFF
--- a/contracts/pair/src/strings.rs
+++ b/contracts/pair/src/strings.rs
@@ -19,7 +19,7 @@ impl TakeFirstNCharsAndConcat for String {
     fn concat(&self, e: &Env, other: String) -> String {
         let len_0 = self.len() as usize;
         let len_1 = other.len() as usize;
-        let mut slice: [u8; 100] = [0; 100];
+        let mut slice: [u8; 35] = [0; 35];
         let combined_len = len_0 + len_1;
 
         self.copy_into_slice(&mut slice[..len_0]);


### PR DESCRIPTION
Fix#168